### PR TITLE
マッチ以前に文字列が存在した場合の結合不備対応

### DIFF
--- a/src/converters/RomaToKanaConverter.ts
+++ b/src/converters/RomaToKanaConverter.ts
@@ -62,6 +62,9 @@ export class RomaToKanaConverter extends BaseConverter {
 				this.appendConvertedWord(
 					word.substring(replaceStartIndex, match.index)
 				);
+
+				// 変換範囲を保存
+				replaceStartIndex += match.index - replaceStartIndex;
 			}
 
 			// 変換範囲を抽出


### PR DESCRIPTION
## マッチ以前に文字列が存在した場合の結合不備対応
掲題通り