### PR TITLE
数値を変換できない不具合対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "al-kana-fluffy-converter",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "al-kana-fluffy-converter",
-			"version": "0.0.2",
+			"version": "0.0.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/core": "^7.22.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "al-kana-fluffy-converter",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"description": "ふんわりと英語をカタカナに変換します",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/Converter.ts
+++ b/src/Converter.ts
@@ -121,7 +121,7 @@ export class Converter {
 		const additionalValue = this.convertAdditionalConversion(
 			this.beforeWord
 		);
-		if (utils.hasAlphabet(additionalValue) === false) {
+		if (utils.hasKanaOnly(additionalValue) === true) {
 			return additionalValue;
 		}
 
@@ -131,13 +131,13 @@ export class Converter {
 		this.afterWord = this.workWords.map((value) => {
 			// 名詞に変換
 			value = this.convertNoun(value);
-			if (utils.hasAlphabet(value) === false) {
+			if (utils.hasKanaOnly(value) === true) {
 				return value;
 			}
 
 			if (this.isConvertNumbers === true) {
 				// 数字の場合
-				if (new RegExp("\\d+").test(value) === true) {
+				if (utils.hasNumber(value) === true) {
 					return this.convertNumber(value);
 				}
 			}

--- a/src/utils/regExp.ts
+++ b/src/utils/regExp.ts
@@ -19,6 +19,15 @@ export function hasAlphabet(value: string) {
 	return reg.test(value);
 }
 
+export function hasNumber(value: string) {
+	const reg = new RegExp("\\d");
+	return reg.test(value);
+}
+
+export function hasKanaOnly(value: string) {
+	return hasAlphabet(value) === false && hasNumber(value) === false;
+}
+
 export function replaceSymbolToSpaceOrOmit(value: string) {
 	// 除外
 	const omitValue = value.replace(new RegExp("'", "g"), "");


### PR DESCRIPTION
## 数値を変換できない不具合対応
「アルファベットが存在しない」場合は、変換が完了したと見なし処理を終了していた
しかし、上記判定に数字の考慮が無かったため、数字が未変換であるにも関わらず処理が終了していた

「アルファベットが存在しない」かつ「数字が存在しない」場合に変換完了とするよう修正した